### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/ess-view-data.el
+++ b/ess-view-data.el
@@ -64,6 +64,10 @@
 
 (require 'ess-inf)
 (require 'ess-rdired)
+(require 'ess-r-mode)
+(require 'ess-r-completion)
+(require 'subr-x)
+(require 'json)
 
 (defgroup ess-view-data ()
   "ess-view-dat"


### PR DESCRIPTION
```
In end of data:
ess-view-data.el:2013:1:Warning: the following functions are not known to be defined: ess-r-mode,
    json-read-from-string, ess-r-get-rcompletions, string-blank-p
```