### PR TITLE
Transient

### DIFF
--- a/ess-view-data.el
+++ b/ess-view-data.el
@@ -6,7 +6,7 @@
 ;; Created: 2019/04/06
 ;; Version: 1.3
 ;; URL: https://github.com/ShuguangSun/ess-view-data
-;; Package-Requires: ((emacs "26.1") (ess "18.10.1") (csv-mode "1.12"))
+;; Package-Requires: ((emacs "26.1") (ess "18.10.1") (csv-mode "1.12") (transient "0.3.7"))
 ;; Keywords: tools
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -96,6 +96,7 @@
 (require 'ess-r-completion)
 (require 'subr-x)
 (require 'json)
+(require 'transient)
 
 (defgroup ess-view-data ()
   "ess-view-dat"
@@ -295,8 +296,38 @@ If enabled, `ansi-color-for-comint-mode-on' should be turn on."
     (define-key keymap (kbd "M-g n") #'ess-view-data-goto-next-page)
     (define-key keymap (kbd "M-g f") #'ess-view-data-goto-first-page)
     (define-key keymap (kbd "M-g l") #'ess-view-data-goto-last-page)
+    (define-key keymap (kbd "?") #'ess-view-data-transient)
     keymap)
   "Keymap for function `ess-view-data-mode'.")
+
+(transient-define-prefix ess-view-data-transient ()
+  "ESS View Data commands."
+  [["Navigation"
+   ("n" "Next page" ess-view-data-goto-next-page)
+   ("p" "Previous page" ess-view-data-goto-previous-page)
+   ("F" "First page" ess-view-data-goto-first-page)
+   ("l" "Last page" ess-view-data-goto-last-page)
+   ("g" "Goto page" ess-view-data-goto-page-number)]
+  ["View"
+   ("t" "Toggle maxprint" ess-view-data-toggle-maxprint)
+   ("P" "Print" ess-view-data-print-ex)]
+  ["Data Manipulation"
+   ("s" "Select columns" ess-view-data-select)
+   ("u" "Unselect columns" ess-view-data-unselect)
+   ("f" "Filter rows" ess-view-data-filter)
+   ("o" "Sort" ess-view-data-sort)
+   ("i" "Slice" ess-view-data-slice)
+   ("m" "Mutate" ess-view-data-mutate)
+   ("<tab>" "Long to wide" ess-view-data-long2wide)
+   ("C-<tab>" "Wide to long" ess-view-data-wide2long)]
+  ["Summarize"
+   ("c" "Count" ess-view-data-count)
+   ("U" "Unique" ess-view-data-unique)
+   ("v" "Summarise" ess-view-data-summarise)]
+  ["Other"
+   ("r" "Reset" ess-view-data-reset)
+   ("w" "Save" ess-view-data-save)
+   ("q" "Quit" ess-view-data-quit)]])
 
 ;;; Indirect Buffers Minor Mode
 (defvar ess-view-data-edit-mode-map

--- a/ess-view-data.el
+++ b/ess-view-data.el
@@ -221,6 +221,11 @@ If enabled, `ansi-color-for-comint-mode-on' should be turn on."
                  (function :tag "Other"))
   :group 'ess-view-data)
 
+(defcustom ess-view-data-auto-show-transient nil
+  "Whether to automatically show the transient menu when opening an ess-view-data buffer."
+  :type 'boolean
+  :group 'ess-view-data)
+
 
 ;; TODO: configure input functions here
 (defvar ess-view-data-backend-setting
@@ -2137,7 +2142,9 @@ Optional argument PNUMBER The page number to go to."
                                ess-view-data-total-page))
                 "]"))
         (force-mode-line-update)
-        (add-hook 'kill-buffer-hook #'ess-view-data-kill-buffer-hook nil t))))
+        (add-hook 'kill-buffer-hook #'ess-view-data-kill-buffer-hook nil t)
+        (when ess-view-data-auto-show-transient
+          (ess-view-data-transient)))))
 
 (defun ess-view-data-print-ex (&optional obj proc-name maxprint)
   "Do print.

--- a/ess-view-data.el
+++ b/ess-view-data.el
@@ -323,15 +323,17 @@ If enabled, `ansi-color-for-comint-mode-on' should be turn on."
    ("o" "Sort" ess-view-data-sort)
    ("i" "Slice" ess-view-data-slice)
    ("m" "Mutate" ess-view-data-mutate)
-   ("<tab>" "Long to wide" ess-view-data-long2wide)
-   ("C-<tab>" "Wide to long" ess-view-data-wide2long)]
+   ("<tab>" "Long to wide (pivot_wider)" ess-view-data-long2wide-pivot-wider)
+   ("C-<tab>" "Wide to long (pivot_longer)" ess-view-data-wide2long-pivot-longer)]
   ["Summarize"
    ("c" "Count" ess-view-data-count)
    ("U" "Unique" ess-view-data-unique)
-   ("v" "Summarise" ess-view-data-summarise)]
+   ("v" "Summarise" ess-view-data-summarise)
+   ("S" "Skimr" ess-view-data-skimr)]
   ["Other"
+   ("V" "Any data manipulation verb" ess-view-data-verbs)
    ("r" "Reset" ess-view-data-reset)
-   ("w" "Save" ess-view-data-save)
+   ("w" "Save to csv file" ess-view-data-save)
    ("q" "Quit" ess-view-data-quit)]])
 
 ;;; Indirect Buffers Minor Mode
@@ -1931,12 +1933,23 @@ Optional argument PROMPT prompt for `read-string'."
   (interactive)
   (ess-view-data-do-apply 'update 'wide2long t nil t))
 
+;; wide2long
+(defun ess-view-data-wide2long-pivot-longer ()
+  "Do wide2long using 'pivot_longer'."
+  (interactive)
+  (ess-view-data-do-apply 'update 'wide2long-pivot_longer t nil t))
 
 ;; long2wide
 (defun ess-view-data-long2wide ()
   "Do long2wide."
   (interactive)
   (ess-view-data-do-apply 'update 'long2wide t nil t))
+
+;; long2wide - Pivot_wider
+(defun ess-view-data-long2wide-pivot-wider ()
+  "Do long2wide using 'pivot_wider'."
+  (interactive)
+  (ess-view-data-do-apply 'update 'long2wide-pivot_wider t nil t))
 
 ;; update
 (defun ess-view-data-update ()


### PR DESCRIPTION
Hi,

Your package is fantastic (a real missing piece in the R-Emacs ecosystem). I propose in this PR a small enhancement: a transient menu that avoids the need to learn the `ess-view-data-mode-map`. This PR does not break any compatibility, but adds one key in the map: "?" to open the transient menu and one custom variable `ess-view-data-auto-show-transient`, initialized to `nil`, to control whether the transient menu should automatically open. New users or users who don't want to learn the keymap can just use the transient.

Note that, even with the transient menu active, the active buffer is the `ess-view-data` buffer, so the standard keymap is still active.

Below is a screenshot of this menu:
![image](https://github.com/user-attachments/assets/6659ad28-0ee8-484c-b3d1-4411757e3dff)

