### PR TITLE
Change the ls call to filter data.frame

### DIFF
--- a/ess-view-data.el
+++ b/ess-view-data.el
@@ -2223,7 +2223,7 @@ Optional argument MAXPRINT maxprint."
                  ;; (current-word)
                  (funcall ess-view-data-read-string
                   "Object: "
-                  (ess-get-words-from-vector "ls(envir = .GlobalEnv)\n")
+                  (ess-get-words-from-vector "Filter(function(x) inherits(get(x, envir = .GlobalEnv), 'data.frame'), ls(envir = .GlobalEnv))\n")
                   nil nil (current-word)))))
     (pop-to-buffer (ess-view-data-print-ex obj maxprint))))
 


### PR DESCRIPTION
Thanks for merging my PR.

Here is another small one. It filters the object from the R environment to present only those that inherits from data.frame. This allows to jump much more quickly to the object, when a lot of non-data.frame objects are in memory.

This should solve #13.