### PR TITLE
Replace initial-input by def in completing-read

### DIFF
--- a/ess-view-data.el
+++ b/ess-view-data.el
@@ -2223,8 +2223,8 @@ Optional argument MAXPRINT maxprint."
                  ;; (current-word)
                  (funcall ess-view-data-read-string
                   "Object: "
-                  (ess-get-words-from-vector "Filter(function(x) inherits(get(x, envir = .GlobalEnv), 'data.frame'), ls(envir = .GlobalEnv))\n")
-                  nil nil (current-word)))))
+                  (ess-get-words-from-vector "Filter(function(x) inherits(get(x, envir = .GlobalEnv), 'data.frame'), c(ls(envir = .GlobalEnv), '.Last.value'))\n")
+                  nil nil nil nil (current-word)))))
     (pop-to-buffer (ess-view-data-print-ex obj maxprint))))
 
 


### PR DESCRIPTION
Currently, `completing-read` proposes a initial input that is the object under the point. The drawback of this is that if I want another object, I have to delete the text. Here, I have simply replaced the initial-input by the default input. This is what is suggested by the docstring of the `completing-read` function:

> This feature is deprecated--it is best to pass nil for INITIAL-INPUT and supply the default value DEF instead.

If I wants the object under the point, I just have to press return as before, but if I want something else, I can start typing.

I have also included '.Last.value' in the completion candidates so the most recently evaluated value can be selected if it is a data.frame. This is useful when doing interactive work in the REPL to be able to explore the last object.